### PR TITLE
Update base_controller.rb

### DIFF
--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -1,4 +1,4 @@
-class BaseController < ActionController::Base
+class BaseController < ApplicationController
   layout 'rails_performance/layouts/rails_performance'
 
   before_action :verify_access


### PR DESCRIPTION
Make BaseController a subclass of ApplicationController rather than directly from ActionController::Base, so that app-specific code can be used in verifying access.

Maybe I'm missing something, but I couldn't see any other good way to get at current_user in the context of the rails performance controller. Clearance puts that on the application's own main controller, not on ActionController::Base.