### PR TITLE
Fix days calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Just clone the repo, setup dummy app (`rails db:migrate`).
 After this:
 
 - rails s
-- rake tests
+- rake test
 
 Like a regular web development.
 

--- a/lib/rails_performance/utils.rb
+++ b/lib/rails_performance/utils.rb
@@ -40,7 +40,7 @@ module RailsPerformance
     end
 
     def Utils.days
-      (RP.duration % 24.days).parts[:days] + 1
+      (RP.duration / 1.day) + 1
     end
 
     def Utils.median(array)


### PR DESCRIPTION
Closes #4 

This implements the correct way to calculate days. This simultaneously reduces the dependency on ActiveSupport::Duration#%(modulo) method. 

Prior to Rails 5.2, the % method in ActiveSupport::Duration returns an integer. Whereas in 5.2+, the modulo method returns an ActiveSupport::Duration