### PR TITLE
Changing `&` to `.try` for ruby 2.2 support

### DIFF
--- a/app/views/rails_performance/rails_performance/requests.html.erb
+++ b/app/views/rails_performance/rails_performance/requests.html.erb
@@ -26,7 +26,7 @@
           <% c, a = groups[0].split("#") %>
           <tr>
             <td><%= link_to groups[0],  rails_performance.rails_performance_summary_path({controller_eq: c, action_eq: a}), remote: true %></td>
-            <td><%= link_to groups[1]&.upcase,  rails_performance.rails_performance_summary_path({controller_eq: c, action_eq: a, format_eq: groups[1]}), remote: true %></td>
+            <td><%= link_to groups[1].try(:upcase),  rails_performance.rails_performance_summary_path({controller_eq: c, action_eq: a, format_eq: groups[1]}), remote: true %></td>
             <td><%= e[:count] %></td>
             <td class="nowrap"><%= ms e[:duration_average] %></td>
             <td class="nowrap"><%= ms e[:view_runtime_average] %></td>


### PR DESCRIPTION
Related with https://github.com/igorkasyanchuk/rails_performance/issues/10
At the end, I just found one place where `&` was used, so it wasn't a big deal.
Overall seems to be working ok for ruby 2.2/rails 4.2 (at least in dev. environment)