### PR TITLE
Route mounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,41 @@ All data are stored in `local` Redis and not sent to any 3rd party servers.
 
 ## Production
 
-Gem is production-ready. At least on my 2 applications with ~800 unique users per day it works perfectly. 
+Gem is production-ready. At least on my 2 applications with ~800 unique users per day it works perfectly.
 
 Just don't forget to protect performance dashboard with http basic auth or check of current_user.
 
-## Usage
+## Installation
+Add this line to your application's Gemfile:
 
-```
-1. Add gem to the Gemfile (in appropriate group if needed)
-2. Start rails server
-3. Make a few requests to your app
-4. open localhost:3000/rails/performance
-5. Tune the configuration and deploy to production
+```ruby
+gem 'rails_performance'
+
+# or
+
+group :development, :production do
+  gem 'rails_performance'
+end
 ```
 
-Default configulation is listed below. But you can overide it.
+Then execute:
+```bash
+$ bundle
+```
+
+And mount the dashboard in your `config/routes.rb`:
+
+```ruby
+mount RailsPerformance::Engine, at: 'admin/performance'
+```
+
+You must also have installed Redis server, because this gem is storing data into it.
+
+After installation and configuration, start your Rails application, make a few requests, and open [localhost:3000/admin/performance](http://localhost:3000/admin/performance).
+
+## Configuring
+
+Default configuration is listed below. But you can overide it.
 
 Create `config/initializers/rails_performance.rb` in your app:
 
@@ -61,27 +81,13 @@ RailsPerformance.setup do |config|
 end if defined?(RailsPerformance)
 ```
 
-## Installation
-Add this line to your application's Gemfile:
+In case you want to authenticate with Devise, use:
 
 ```ruby
-gem 'rails_performance'
-
-# or 
-
-group :development, :production do
-  gem 'rails_performance'
+authenticate :user, -> (user) { user.admin? } do
+  mount RailsPerformance::Engine, at: 'admin/performance'
 end
 ```
-
-And then execute:
-```bash
-$ bundle
-```
-
-You must also have installed Redis server, because this gem is storing data into it.
-
-After installation and configuration, start your Rails application, make a few requests, and open `https://localhost:3000/rails/performance` URL.
 
 ## How it works
 

--- a/app/views/rails_performance/rails_performance/crashes.html.erb
+++ b/app/views/rails_performance/rails_performance/crashes.html.erb
@@ -25,7 +25,7 @@
         <% @data.each do |e| %>
           <tr>
             <td><%= format_datetime e[:datetime] %></td>
-            <td><%= link_to e[:controller] + '#' + e[:action], rails_performance.rails_performance_summary_path({controller_eq: e[:controller], action_eq: e[:action]}), remote: true %></td>
+            <td><%= link_to e[:controller] + '#' + e[:action], summary_path({controller_eq: e[:controller], action_eq: e[:action]}), remote: true %></td>
             <td><%= e[:method] %></td>
             <td><%= e[:format] %></td>
             <td><%= link_to_path(e) %></td>

--- a/app/views/rails_performance/rails_performance/recent.html.erb
+++ b/app/views/rails_performance/rails_performance/recent.html.erb
@@ -28,13 +28,13 @@
           <tr>
             <td>
               <% if e[:request_id].present? %>
-                <%= link_to rails_performance.rails_performance_trace_path(id: e[:request_id]), remote: true do %>
+                <%= link_to trace_path(id: e[:request_id]), remote: true do %>
                   <span class="stats_icon_max"><%= icon 'activity' %></span>
                 <% end %>
               <% end %>
             </td>
             <td><%= format_datetime e[:datetime] %></td>
-            <td><%= link_to e[:controller] + '#' + e[:action], rails_performance.rails_performance_summary_path({controller_eq: e[:controller], action_eq: e[:action]}), remote: true %></td>
+            <td><%= link_to e[:controller] + '#' + e[:action], summary_path({controller_eq: e[:controller], action_eq: e[:action]}), remote: true %></td>
             <td><%= e[:method] %></td>
             <td><%= e[:format] %></td>
             <td><%= link_to_path(e) %></td>
@@ -44,7 +44,7 @@
             <td class="nowrap"><%= ms e[:db_runtime] %></td>
             <td>
               <% if e[:request_id].present? %>
-                <%= link_to rails_performance.rails_performance_trace_path(id: e[:request_id]), remote: true do %>
+                <%= link_to trace_path(id: e[:request_id]), remote: true do %>
                   <span class="stats_icon_max"><%= icon 'activity' %></span>
                 <% end %>
               <% end %>

--- a/app/views/rails_performance/rails_performance/requests.html.erb
+++ b/app/views/rails_performance/rails_performance/requests.html.erb
@@ -26,7 +26,7 @@
           <% c, a = groups[0].split("#") %>
           <tr>
             <td><%= link_to groups[0],  rails_performance.rails_performance_summary_path({controller_eq: c, action_eq: a}), remote: true %></td>
-            <td><%= link_to groups[1]&.upcase,  rails_performance.rails_performance_summary_path({controller_eq: c, action_eq: a, format_eq: groups[1]}), remote: true %></td>
+            <td><%= link_to groups[1].try(:upcase),  rails_performance.rails_performance_summary_path({controller_eq: c, action_eq: a, format_eq: groups[1]}), remote: true %></td>
             <td><%= e[:count] %></td>
             <td class="nowrap"><%= ms e[:duration_average] %></td>
             <td class="nowrap"><%= ms e[:view_runtime_average] %></td>

--- a/app/views/rails_performance/rails_performance/requests.html.erb
+++ b/app/views/rails_performance/rails_performance/requests.html.erb
@@ -25,8 +25,8 @@
           <% groups = e[:group].split("|") %>
           <% c, a = groups[0].split("#") %>
           <tr>
-            <td><%= link_to groups[0],  rails_performance.rails_performance_summary_path({controller_eq: c, action_eq: a}), remote: true %></td>
-            <td><%= link_to groups[1].try(:upcase),  rails_performance.rails_performance_summary_path({controller_eq: c, action_eq: a, format_eq: groups[1]}), remote: true %></td>
+            <td><%= link_to groups[0],  summary_path({controller_eq: c, action_eq: a}), remote: true %></td>
+            <td><%= link_to groups[1].try(:upcase),  summary_path({controller_eq: c, action_eq: a, format_eq: groups[1]}), remote: true %></td>
             <td><%= e[:count] %></td>
             <td class="nowrap"><%= ms e[:duration_average] %></td>
             <td class="nowrap"><%= ms e[:view_runtime_average] %></td>

--- a/app/views/rails_performance/shared/_header.html.erb
+++ b/app/views/rails_performance/shared/_header.html.erb
@@ -1,7 +1,7 @@
 
 <nav class="navbar" role="navigation" aria-label="main navigation">
   <div class="navbar-brand">
-    <%= link_to rails_performance.rails_performance_url, class: "navbar-item logo" do %>
+    <%= link_to root_url, class: "navbar-item logo" do %>
       <h2>Rails Performance</h2>
     <% end %>
 
@@ -14,12 +14,12 @@
 
   <div id="navbarBasicExample" class="navbar-menu">
     <div class="navbar-start">
-      <%= link_to 'Dashboard', rails_performance.rails_performance_url, class: "navbar-item #{active?(:dashboard)}" %>
-      <%= link_to 'Requests Analysis', rails_performance.rails_performance_requests_url, class: "navbar-item #{active?(:requests)}" %>
-      <%= link_to '500 Errors', rails_performance.rails_performance_crashes_url, class: "navbar-item #{active?(:crashes)}" %>
-      <%= link_to 'Recent Requests', rails_performance.rails_performance_recent_url, class: "navbar-item #{active?(:recent)}" %>
+      <%= link_to 'Dashboard', root_url, class: "navbar-item #{active?(:dashboard)}" %>
+      <%= link_to 'Requests Analysis', requests_url, class: "navbar-item #{active?(:requests)}" %>
+      <%= link_to '500 Errors', crashes_url, class: "navbar-item #{active?(:crashes)}" %>
+      <%= link_to 'Recent Requests', recent_url, class: "navbar-item #{active?(:recent)}" %>
       <% if defined?(Sidekiq) %>
-        <%= link_to 'Sidekiq', rails_performance.rails_performance_jobs_url, class: "navbar-item #{active?(:jobs)}" %>
+        <%= link_to 'Sidekiq', jobs_url, class: "navbar-item #{active?(:jobs)}" %>
       <% end %>
     </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,21 +1,12 @@
 RailsPerformance::Engine.routes.draw do
-  get '/'          => 'rails_performance#index', as: :rails_performance
+  root to: "rails_performance#index"
 
-  get '/requests'  => 'rails_performance#requests', as: :rails_performance_requests
-  get '/crashes'   => 'rails_performance#crashes', as: :rails_performance_crashes
-  get '/recent'    => 'rails_performance#recent', as: :rails_performance_recent
+  get '/requests', to: 'rails_performance#requests'
+  get '/crashes', to: 'rails_performance#crashes'
+  get '/recent', to: 'rails_performance#recent'
 
-  get '/trace/:id'  => 'rails_performance#trace', as: :rails_performance_trace
-  get '/summary'    => 'rails_performance#summary', as: :rails_performance_summary
+  get '/trace/:id', to: 'rails_performance#trace', as: :trace
+  get '/summary', to: 'rails_performance#summary'
 
-  get '/jobs'       => 'rails_performance#jobs', as: :rails_performance_jobs
-end
-
-Rails.application.routes.draw do
-  begin
-    mount RailsPerformance::Engine => '/rails/performance', as: 'rails_performance'
-  rescue ArgumentError
-      # already added
-      # this cod exist here because engine not includes routing automatically
-  end
+  get '/jobs', to: 'rails_performance#jobs'
 end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount RailsPerformance::Engine, at: 'rails/performance'
+
   namespace :account do
     get 'site/about'
     get 'site/crash'


### PR DESCRIPTION
`rails/performance` looks like a good path, but most of the time people tend to use `admin/something` for all their administration stack.
Indeed in my current work, there's a whole security system configured out of the rails scope, where any url starting with `/admin` is only accessible in the office or via VPN, so I made the changes to mount this engine into `/admin/performance`.
Also, I updated the readme to show how to make this work with the manual mounting (besides I removed #Usage section and moved up #Installation, which it was pretty much the same info) and gave some basic info about how to authenticate with devise.
Just in case, this is something that other rails engines also do, like [rails_admin](https://github.com/sferik/rails_admin) or [pghero](https://github.com/ankane/pghero) to mention a few of them, where the dev decides what's the route they want to.