### PR TITLE
Support mount url in metrics collector

### DIFF
--- a/lib/rails_performance/instrument/metrics_collector.rb
+++ b/lib/rails_performance/instrument/metrics_collector.rb
@@ -18,7 +18,8 @@ module RailsPerformance
       def call(event_name, started, finished, event_id, payload)
         event = ActiveSupport::Notifications::Event.new(event_name, started, finished, event_id, payload)
 
-        return if event.payload[:path] =~ /^\/rails\/performance/
+        mount_url = RailsPerformance.mount_at || "/rails/performance/"
+        return if event.payload[:path] =~ /^#{Regexp.escape(mount_url)}/ 
 
         record = {
           controller: event.payload[:controller],


### PR DESCRIPTION
This will prevent rails perf from tracking itself when you use mount_at