### PR TITLE
Support for ignored endpoints

### DIFF
--- a/lib/generators/rails_performance/install/templates/initializer.rb
+++ b/lib/generators/rails_performance/install/templates/initializer.rb
@@ -17,4 +17,7 @@ RailsPerformance.setup do |config|
   config.verify_access_proc = proc { |controller| true }
   # for example when you have `current_user`
   # config.verify_access_proc = proc { |controller| controller.current_user && controller.current_user.admin? }
+  
+  # You can ignore endpoints with Rails standard notation controller#action
+  # config.ignored_endpoints = ['HomeController#contact']
 end if defined?(RailsPerformance)

--- a/lib/rails_performance.rb
+++ b/lib/rails_performance.rb
@@ -54,6 +54,9 @@ module RailsPerformance
   mattr_accessor :verify_access_proc
   @@verify_access_proc = proc { |controller| true }
 
+  mattr_accessor :ignored_endpoints
+  @@ignored_endpoints = []
+
   def self.setup
     yield(self)
   end

--- a/lib/rails_performance.rb
+++ b/lib/rails_performance.rb
@@ -54,7 +54,10 @@ module RailsPerformance
   mattr_accessor :verify_access_proc
   @@verify_access_proc = proc { |controller| true }
 
-  mattr_accessor :ignored_endpoints
+  mattr_reader :ignored_endpoints
+  def RailsPerformance.ignored_endpoints=(endpoints)
+    @@ignored_endpoints = Set.new(endpoints)
+  end
   @@ignored_endpoints = []
 
   def self.setup

--- a/lib/rails_performance/engine.rb
+++ b/lib/rails_performance/engine.rb
@@ -1,3 +1,4 @@
+require 'action_view/log_subscriber'
 require_relative './rails/middleware.rb'
 require_relative './models/collection.rb'
 require_relative './instrument/metrics_collector.rb'

--- a/lib/rails_performance/instrument/metrics_collector.rb
+++ b/lib/rails_performance/instrument/metrics_collector.rb
@@ -18,8 +18,8 @@ module RailsPerformance
       def call(event_name, started, finished, event_id, payload)
         event = ActiveSupport::Notifications::Event.new(event_name, started, finished, event_id, payload)
 
-        mount_url = RailsPerformance.mount_at || "/rails/performance/"
-        return if event.payload[:path] =~ /^#{Regexp.escape(mount_url)}/ 
+        return if %r{#{RailsPerformance.mount_at}}.match? event.payload[:path]
+        return if RailsPerformance.ignored_endpoints.include? "#{event.payload[:controller]}##{event.payload[:action]}"
 
         record = {
           controller: event.payload[:controller],

--- a/lib/rails_performance/utils.rb
+++ b/lib/rails_performance/utils.rb
@@ -60,8 +60,7 @@ module RailsPerformance
     def Utils.save_to_redis(key, value, expire = RP.duration.to_i)
       # puts "  [SAVE]    key  --->  #{key}\n"
       # puts "          value  --->  #{value.to_json}\n\n"
-      RP.redis.set(key, value.to_json)
-      RP.redis.expire(key, expire.to_i)
+      RP.redis.set(key, value.to_json, ex: expire.to_i)
     end
 
   end

--- a/test/rails_performance_controller_test.rb
+++ b/test/rails_performance_controller_test.rb
@@ -1,15 +1,45 @@
 require 'test_helper'
 
 class RailsPerformanceControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    reset_redis
+  end
+
+  def requests_report_data
+    source = RP::DataSource.new(type: :requests, klass: RP::Models::Record)
+    RP::Reports::RequestsReport.new(source.db, group: :controller_action_format).data
+  end
+
   test "should get home page" do
+    assert_equal requests_report_data.size, 0
     setup_db
+    assert_equal requests_report_data.size, 1
     get '/'
+    assert_equal requests_report_data.size, 2
     assert_response :success
+  end
+
+  test "should respect ignored_endpoints configuration value" do
+    assert_equal requests_report_data.size, 0
+    get '/home/contact'
+    assert_equal requests_report_data.size, 1
+    assert_equal requests_report_data.first[:group], "HomeController#contact|html"
+    reset_redis
+    assert_equal requests_report_data.size, 0
+    
+    original_ignored_endpoints = RP.ignored_endpoints
+    RP.ignored_endpoints = ['HomeController#contact']
+    get '/home/contact'
+    assert_equal requests_report_data.size, 0
+    RP.ignored_endpoints = original_ignored_endpoints
   end
 
   test "should get index" do
     setup_db
+    assert_equal requests_report_data.size, 1
     get '/rails/performance'
+    # make sure rails/performance paths are ignored
+    assert_equal requests_report_data.size, 1
     assert_response :success
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -50,6 +50,10 @@ def dummy_job_event(worker: 'Worker', queue: 'default', jid: "jxzet-#{Time.now.t
   }
 end
 
+def reset_redis
+  RP.redis.redis.flushall
+end
+
 def setup_db(event = dummy_event)
   RailsPerformance::Utils.log_request_in_redis(event)
 end


### PR DESCRIPTION
Hey! This adds support for ignoring certain endpoints like status endpoint for example.

So now you can do

```ruby
config.ignored_endpoints = ['StatusController#main']
```

It's actually very similar to how it can be done in https://github.com/skylightio/skylight-ruby.

I also added some small improvements which I thought make sense. Basically only

- Cleaning redis before test cases
- Redis set and expire in one command
- use `match?` instead of `~=` (faster)

Hope this is OK.