### PR TITLE
Support redis cluster by default

### DIFF
--- a/lib/rails_performance.rb
+++ b/lib/rails_performance.rb
@@ -23,7 +23,7 @@ module RailsPerformance
   FORMAT = "%Y%m%dT%H%M"
 
   mattr_accessor :redis
-  @@redis = Redis::Namespace.new("#{::Rails.env}-rails-performance", redis: Redis.new)
+  @@redis = Redis::Namespace.new("{#{::Rails.env}-rails-performance}", redis: Redis.new)
 
   mattr_accessor :duration
   @@duration = 4.hours


### PR DESCRIPTION
Addresses #25 

I think it's better to just change the default key instead of telling the user to change the whole redis adapter in order to get support for redis cluster.