### PR TITLE
Rake task integration: respect enabled setting

### DIFF
--- a/lib/rails_performance/engine.rb
+++ b/lib/rails_performance/engine.rb
@@ -56,11 +56,11 @@ module RailsPerformance
 
       ActionView::LogSubscriber.send :prepend, RailsPerformance::Extensions::View
       ActiveRecord::LogSubscriber.send :prepend, RailsPerformance::Extensions::Db
-    end
 
-    if defined?(::Rake::Task)
-      require_relative './gems/rake_ext.rb'
-      RailsPerformance::Gems::RakeExt.init
+      if defined?(::Rake::Task)
+        require_relative './gems/rake_ext.rb'
+        RailsPerformance::Gems::RakeExt.init
+      end
     end
   end
 end


### PR DESCRIPTION
Hi @igorkasyanchuk!

I just upgraded to 1.0.0 and my CI pipeline crashed because the new rake task integration does not respect the `RailsPerformance.enabled` setting.