### PR TITLE
Add home button link customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ RailsPerformance.setup do |config|
   config.verify_access_proc = proc { |controller| true }
   # for example when you have `current_user`
   # config.verify_access_proc = proc { |controller| controller.current_user && controller.current_user.admin? }
+
+  # config home button link
+  config.home_link = '/'
 end if defined?(RailsPerformance)
 ```
 

--- a/app/views/rails_performance/shared/_header.html.erb
+++ b/app/views/rails_performance/shared/_header.html.erb
@@ -35,7 +35,7 @@
       <div class="navbar-item">
         <div class="buttons">
           <%#= link_to 'Export to CSV', '#', target: '_blank', class: "button is-primary" %>
-          <%= link_to '/', target: '_blank', class: "button is-light home_icon" do %>
+          <%= link_to RailsPerformance.home_link, target: '_blank', class: "button is-light home_icon" do %>
             <%= icon('home') %>
           <% end %>
         </div>

--- a/lib/generators/rails_performance/install/templates/initializer.rb
+++ b/lib/generators/rails_performance/install/templates/initializer.rb
@@ -17,7 +17,10 @@ RailsPerformance.setup do |config|
   config.verify_access_proc = proc { |controller| true }
   # for example when you have `current_user`
   # config.verify_access_proc = proc { |controller| controller.current_user && controller.current_user.admin? }
-  
+
   # You can ignore endpoints with Rails standard notation controller#action
   # config.ignored_endpoints = ['HomeController#contact']
+
+  # config home button link
+  config.home_link = '/'
 end if defined?(RailsPerformance)

--- a/lib/rails_performance.rb
+++ b/lib/rails_performance.rb
@@ -69,6 +69,10 @@ module RailsPerformance
   mattr_accessor :skip
   @@skip = false
 
+  # config home button link
+  mattr_accessor :home_link
+  @@home_link = '/'
+
   def RailsPerformance.setup
     yield(self)
   end

--- a/test/dummy/config/initializers/rails_performance.rb
+++ b/test/dummy/config/initializers/rails_performance.rb
@@ -16,4 +16,7 @@ RailsPerformance.setup do |config|
   config.verify_access_proc = proc { |controller| true }
   # for example when you have `current_user`
   # config.verify_access_proc = proc { |controller| controller.current_user && controller.current_user.admin? }
+
+  # config home button link
+  config.home_link = '/'
 end if defined?(RailsPerformance)


### PR DESCRIPTION
Hi!
First of all, thanks for your great work here, this gem is a great self-host alternative to Scout/New relics.

So, this little pull request add the possibility to change the url/path of the home button.

In my case, I need the button to redirect to our backoffice ('/admin') rather than the main app in the root ('/').
I also use the Sidekiq web-ui and it allows us to configure the similar 'Back to the app' button (see: https://github.com/mperham/sidekiq/blob/3330df0ee37cfd3e0cd3ef01e3e66b584b99d488/web/views/_nav.erb#L12)

Hope this is fine 😄 