### PR TITLE
Set scroll for overflow-x on tables

### DIFF
--- a/app/views/rails_performance/stylesheets/style.css
+++ b/app/views/rails_performance/stylesheets/style.css
@@ -81,6 +81,9 @@
   border-bottom: 1px solid red;
 }
 
+.card-content {
+  overflow-x: scroll;
+}
 
 table th[data-sort] {
   cursor: pointer;


### PR DESCRIPTION
The content of the "Format" and "Controller Action" table column sometimes cause the table to be too wide which causes it to spill out of the `<div class="card-content>`. Setting the overflow-x to scroll handles this issue.