### PR TITLE
Add skipable rake config

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ RailsPerformance.setup do |config|
 
   # config home button link
   config.home_link = '/'
+
+  config.skipable_rake_tasks = ['webpacker:compile']
 end if defined?(RailsPerformance)
 ```
 

--- a/lib/rails_performance.rb
+++ b/lib/rails_performance.rb
@@ -73,6 +73,10 @@ module RailsPerformance
   mattr_accessor :home_link
   @@home_link = '/'
 
+  # skip performance tracking for these rake tasks
+  mattr_accessor :skipable_rake_tasks
+  @@skipable_rake_tasks = []
+
   def RailsPerformance.setup
     yield(self)
   end

--- a/lib/rails_performance/gems/rake_ext.rb
+++ b/lib/rails_performance/gems/rake_ext.rb
@@ -13,13 +13,15 @@ module RailsPerformance
               status = 'error'
               raise(ex)
             ensure
-              RailsPerformance::Models::RakeRecord.new(
-                task: RailsPerformance::Gems::RakeExt.find_task_name(*args),
-                datetime: now.strftime(RailsPerformance::FORMAT),
-                datetimei: now.to_i,
-                duration: (Time.now - now) * 1000,
-                status: status,
-              ).save
+              if !RailsPerformance.skipable_rake_tasks.include?(self.name)
+                RailsPerformance::Models::RakeRecord.new(
+                  task: RailsPerformance::Gems::RakeExt.find_task_name(*args),
+                  datetime: now.strftime(RailsPerformance::FORMAT),
+                  datetimei: now.to_i,
+                  duration: (Time.now - now) * 1000,
+                  status: status,
+                ).save
+              end
             end
           end
 

--- a/test/rake_ext_test.rb
+++ b/test/rake_ext_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class RakeExtTest < ActiveSupport::TestCase
+  test "can exclude rake tasks" do
+    skip "This test doesn't work because of circular ref in RakeExt"
+    mock_app = Minitest::Mock.new
+    mock_app.expect(:current_scope, "test")
+
+    RailsPerformance.skipable_rake_tasks = ["skip_this"]
+    RailsPerformance::Gems::RakeExt.init
+
+    subject = Rake::Task.new("skip_this", mock_app)
+    subject.invoke({})
+  end
+end

--- a/test/rake_ext_test.rb
+++ b/test/rake_ext_test.rb
@@ -1,15 +1,32 @@
 require 'test_helper'
+require 'rake'
+
+APP_RAKEFILE = File.expand_path("../test/dummy/Rakefile", __dir__)
+load 'rails/tasks/engine.rake'
+load 'rails/tasks/statistics.rake'
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+require_relative '../lib/rails_performance/gems/rake_ext.rb'
 
 class RakeExtTest < ActiveSupport::TestCase
+  # this test works only when runing "bundle exec rake test"
   test "can exclude rake tasks" do
-    skip "This test doesn't work because of circular ref in RakeExt"
-    mock_app = Minitest::Mock.new
-    mock_app.expect(:current_scope, "test")
-
-    RailsPerformance.skipable_rake_tasks = ["skip_this"]
-    RailsPerformance::Gems::RakeExt.init
-
-    subject = Rake::Task.new("skip_this", mock_app)
+    RailsPerformance.skipable_rake_tasks = ["db:version"]
+    count_before = count_records_in_redis
+    subject = Rake::Task["db:version"]
     subject.invoke({})
+    assert_equal count_before, count_records_in_redis
+
+    RailsPerformance.skipable_rake_tasks = []
+    count_before = count_records_in_redis
+    subject = Rake::Task["db:version"]
+    subject.invoke({})
+    assert_equal count_before + 1, count_records_in_redis
+  end
+
+  def count_records_in_redis
+    datasource = RailsPerformance::DataSource.new(q: {}, type: :rake)
+    db = datasource.db
+    count_before = RailsPerformance::Reports::RecentRequestsReport.new(db).data.size
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,8 @@
 ENV["RAILS_ENV"] = "test"
 
 require 'simplecov'
+require 'minitest/autorun'
+
 SimpleCov.start do
   add_filter 'test/dummy'
 end


### PR DESCRIPTION
When running asset precompile for rails, rails performance gem tries to connect to redis. This change gives the option to exclude certain rake tasks from performance tracking.

Config example:
```ruby
    config.skipable_rake_tasks = ['assets:precompile']
```