### PR TITLE
Depend only on railties instead of rails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,28 +3,13 @@ PATH
   specs:
     rails_performance (1.2.0)
       browser
-      rails
+      railties
       redis
       redis-namespace
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (7.0.4.3)
-      actionpack (= 7.0.4.3)
-      activesupport (= 7.0.4.3)
-      nio4r (~> 2.0)
-      websocket-driver (>= 0.6.1)
-    actionmailbox (7.0.4.3)
-      actionpack (= 7.0.4.3)
-      activejob (= 7.0.4.3)
-      activerecord (= 7.0.4.3)
-      activestorage (= 7.0.4.3)
-      activesupport (= 7.0.4.3)
-      mail (>= 2.7.1)
-      net-imap
-      net-pop
-      net-smtp
     actionmailer (7.0.4.3)
       actionpack (= 7.0.4.3)
       actionview (= 7.0.4.3)
@@ -42,13 +27,6 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actiontext (7.0.4.3)
-      actionpack (= 7.0.4.3)
-      activerecord (= 7.0.4.3)
-      activestorage (= 7.0.4.3)
-      activesupport (= 7.0.4.3)
-      globalid (>= 0.6.0)
-      nokogiri (>= 1.8.5)
     actionview (7.0.4.3)
       activesupport (= 7.0.4.3)
       builder (~> 3.1)
@@ -83,7 +61,7 @@ GEM
     connection_pool (2.4.0)
     crass (1.0.6)
     daemons (1.4.1)
-    date (3.3.3)
+    date (3.3.4)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)
@@ -111,8 +89,8 @@ GEM
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
     erubi (1.12.0)
-    globalid (1.1.0)
-      activesupport (>= 5.0)
+    globalid (1.2.1)
+      activesupport (>= 6.1)
     grape (1.7.0)
       activesupport
       builder
@@ -138,25 +116,25 @@ GEM
     mimemagic (0.4.3)
       nokogiri (~> 1)
       rake
-    mini_mime (1.1.2)
-    mini_portile2 (2.8.1)
+    mini_mime (1.1.5)
+    mini_portile2 (2.8.5)
     minitest (5.18.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     mustermann-grape (1.0.2)
       mustermann (>= 1.0.0)
-    net-imap (0.3.6)
+    net-imap (0.4.4)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.1)
+    net-protocol (0.2.2)
       timeout
-    net-smtp (0.3.3)
+    net-smtp (0.4.0)
       net-protocol
     nio4r (2.5.8)
-    nokogiri (1.14.2)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.15.0)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     otr-activerecord (2.1.2)
@@ -167,26 +145,12 @@ GEM
       method_source (~> 1.0)
     puma (6.2.1)
       nio4r (~> 2.0)
-    racc (1.6.2)
+    racc (1.7.1)
     rack (2.2.6.4)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-test (2.1.0)
       rack (>= 1.3)
-    rails (7.0.4.3)
-      actioncable (= 7.0.4.3)
-      actionmailbox (= 7.0.4.3)
-      actionmailer (= 7.0.4.3)
-      actionpack (= 7.0.4.3)
-      actiontext (= 7.0.4.3)
-      actionview (= 7.0.4.3)
-      activejob (= 7.0.4.3)
-      activemodel (= 7.0.4.3)
-      activerecord (= 7.0.4.3)
-      activestorage (= 7.0.4.3)
-      activesupport (= 7.0.4.3)
-      bundler (>= 1.15.0)
-      railties (= 7.0.4.3)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -231,14 +195,11 @@ GEM
     sqlite3 (1.6.2)
       mini_portile2 (~> 2.8.0)
     thor (1.2.1)
-    timeout (0.4.0)
+    timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
-    websocket-driver (0.7.5)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
     wrapped_print (0.1.1)
       activesupport
     zeitwerk (2.6.7)
@@ -247,6 +208,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionmailer
+  activestorage
   daemons
   delayed_job_active_record
   devise
@@ -263,4 +226,4 @@ DEPENDENCIES
   wrapped_print
 
 BUNDLED WITH
-   2.2.3
+   2.4.21

--- a/lib/rails_performance.rb
+++ b/lib/rails_performance.rb
@@ -1,6 +1,7 @@
 require "redis"
 require "redis-namespace"
 require "browser"
+require 'active_support/core_ext/integer'
 require_relative "./rails_performance/version.rb"
 require_relative "rails_performance/rails/query_builder.rb"
 require_relative "rails_performance/rails/middleware.rb"

--- a/rails_performance.gemspec
+++ b/rails_performance.gemspec
@@ -16,11 +16,13 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "rails"
+  spec.add_dependency "railties"
   spec.add_dependency "redis"
   spec.add_dependency "redis-namespace"
   spec.add_dependency "browser"
 
+  spec.add_development_dependency "activestorage"
+  spec.add_development_dependency "actionmailer"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "grape"


### PR DESCRIPTION
By making rails a dependency, any app adding this gem will inherit all the Rails gems such as activerecord, actioncable, actionmailer, activestorage etc., even if it is not using these optional dependencies itself.

By changing the dependency to just railties, no optional Rails dependencies are forced upon apps.

fix igorkasyanchuk/rails_performance#60