### PR TITLE
Use RailsPerformance.log and minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ RailsPerformance.setup do |config|
   config.redis    = Redis.new(url: ENV["REDIS_URL"].presence || "redis://127.0.0.1:6379/0") # or Redis::Namespace.new("rails-performance", redis: Redis.new), see below in README
   config.duration = 4.hours
 
-  config.debug    = false # currently not used>
+  config.debug    = false
   config.enabled  = true
 
   # configure Recent tab (time window and limit of requests)

--- a/lib/generators/rails_performance/install/templates/initializer.rb
+++ b/lib/generators/rails_performance/install/templates/initializer.rb
@@ -15,7 +15,7 @@ if defined?(RailsPerformance)
     # config.slow_requests_limit = 500 # numnber of slow requests
     config.slow_requests_threshold = 500 # ms
 
-    config.debug = false # currently not used>
+    config.debug = false
     config.enabled = true
 
     # default path where to mount gem

--- a/lib/rails_performance/extensions/resources_monitor.rb
+++ b/lib/rails_performance/extensions/resources_monitor.rb
@@ -79,7 +79,7 @@ module RailsPerformance
       end
 
       def store_data(data)
-        ::Rails.logger.info("Server: #{server_id}, Context: #{context}, Role: #{role}, data: #{data}")
+        RailsPerformance.log "Server: #{server_id}, Context: #{context}, Role: #{role}, data: #{data}"
 
         now = RailsPerformance::Utils.time
         now = now.change(sec: 0, usec: 0)

--- a/test/dummy/config/initializers/rails_performance.rb
+++ b/test/dummy/config/initializers/rails_performance.rb
@@ -3,7 +3,7 @@ if defined?(RailsPerformance)
     config.redis = Redis.new(url: ENV["REDIS_URL"].presence || "redis://127.0.0.1:6379/#{(Rails.env.to_s == "test") ? 1 : 0}")
     config.duration = 6.hours
 
-    config.debug = true # currently not used>
+    config.debug = true
     config.enabled = true
 
     config.recent_requests_time_window = 60.minutes

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_25_100652) do
+ActiveRecord::Schema[8.0].define(version: 2024_11_25_100652) do
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false


### PR DESCRIPTION
Let's use `RailsPerformance.log` for server info to not show this info in user application logs.