### PR TITLE
gitignore ruby version manangement files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ coverage/
 .DS_Store
 
 */**/.DS_Store
+
+.ruby-version
+.ruby-gemset


### PR DESCRIPTION
This PR adds the following to the `.gitignore` file:
```
.ruby-version
.ruby-gemset
```

This allows me to isolate this project from other ruby projects on my same machine when hacking on it. I'm using RVM personally, but my understanding is that these files work with other ruby version management options, like rbenv and chruby. 