### PR TITLE
Filter out slow requests with no duration set

### DIFF
--- a/lib/rails_performance/reports/slow_requests_report.rb
+++ b/lib/rails_performance/reports/slow_requests_report.rb
@@ -10,7 +10,7 @@ module RailsPerformance
           .collect { |e| e.record_hash }
           .select { |e| e if e[sort] > RailsPerformance.slow_requests_time_window.ago.to_i }
           .sort { |a, b| b[sort] <=> a[sort] }
-          .filter { |e| e[:duration] > RailsPerformance.slow_requests_threshold.to_i }
+          .filter { |e| e[:duration].to_f > RailsPerformance.slow_requests_threshold.to_i }
           .first(limit)
       end
 


### PR DESCRIPTION
We have an issue in our application where some of our slow requests are saved into the Rails Performance Redis database without a `duration` value set.

I suspect it's due to this line in the `meta_request` gem

https://github.com/qqshfox/meta_request/blob/master/lib/meta_request/event.rb#L27

This change just converts an empty `duration` value to `0.0` which will mean they are filtered out of the Slow Requests page.