### PR TITLE
Adding cleanup ont ext gems

### DIFF
--- a/lib/rails_performance/gems/custom_ext.rb
+++ b/lib/rails_performance/gems/custom_ext.rb
@@ -24,6 +24,7 @@ module RailsPerformance
             datetime: now.strftime(RailsPerformance::FORMAT),
             datetimei: now.to_i
           ).save
+          CurrentRequest.cleanup
         end
       end
     end

--- a/lib/rails_performance/gems/delayed_job_ext.rb
+++ b/lib/rails_performance/gems/delayed_job_ext.rb
@@ -23,6 +23,7 @@ module RailsPerformance
               status: status
             )
             record.save
+            CurrentRequest.cleanup
           end
         end
 

--- a/lib/rails_performance/gems/grape_ext.rb
+++ b/lib/rails_performance/gems/grape_ext.rb
@@ -25,6 +25,7 @@ module RailsPerformance
 
           if name == "format_response.grape"
             CurrentRequest.current.record.save
+            CurrentRequest.cleanup
           end
         end
       end

--- a/lib/rails_performance/gems/rake_ext.rb
+++ b/lib/rails_performance/gems/rake_ext.rb
@@ -23,6 +23,7 @@ module RailsPerformance
                 duration: (RailsPerformance::Utils.time - now) * 1000,
                 status: status
               ).save
+              CurrentRequest.cleanup
             end
           end
 

--- a/lib/rails_performance/gems/sidekiq_ext.rb
+++ b/lib/rails_performance/gems/sidekiq_ext.rb
@@ -27,6 +27,7 @@ module RailsPerformance
           # store in ms instead of seconds
           record.duration = (RailsPerformance::Utils.time - now) * 1000
           record.save
+          CurrentRequest.cleanup
         end
       end
     end


### PR DESCRIPTION
Fixes #147 

We observed memory leak from the gem on our big jobs on Sidekiq. It was a build-up of SQL requests on the CurrentRequest model. 

We found that the Cleanup method was only called for the web part. We added the CurrentRequest.cleanup after saving the record.
-> We tested and it fixed our memory leaks 

 We also had a look on the other ext gems and we think that it should also have the Cleanup, but we did not test this part.