### PR TITLE
Fix resource chart method name

### DIFF
--- a/app/views/rails_performance/rails_performance/resources.html.erb
+++ b/app/views/rails_performance/rails_performance/resources.html.erb
@@ -3,7 +3,7 @@
 <% @resources_report.servers.each do |server| %>
   <h1 class="title mt-8 pt-8"><%= server.name %></h1>
 
-  <% server.charts.each.with_index do |chart, index| %>
+  <% server.charts.each.with_index(1) do |chart, index| %>
     <div class="card">
       <div class="card-content">
         <h2 class="subtitle"><%= chart.subtitle %></h2>
@@ -12,7 +12,7 @@
       </div>
     </div>
 
-    <br/>
+    <br>
 
     <% content_for :on_load do %>
       <script>

--- a/lib/rails_performance/system_monitor/resource_chart.rb
+++ b/lib/rails_performance/system_monitor/resource_chart.rb
@@ -84,7 +84,7 @@ module RailsPerformance
         )
       end
 
-      def signal measurement
+      def format measurement
         measurement["available"].to_f.round(2)
       end
 


### PR DESCRIPTION
Closes https://github.com/igorkasyanchuk/rails_performance/issues/152
 
Fix resource chart method name and change back index in server charts iteration for better readability of units (old behavior)