### PR TITLE
Add events to usage and percentage charts, too

### DIFF
--- a/app/views/rails_performance/javascripts/app.js
+++ b/app/views/rails_performance/javascripts/app.js
@@ -103,7 +103,8 @@ function showPercentageChart(element_id, data, name) {
     series: [{
       name: name,
       data: data,
-    }]
+    }],
+    annotations: window?.annotationsData || {}
   });
 }
 
@@ -116,7 +117,8 @@ function showUsageChart(element_id, data, name, pow) {
     series: [{
       name: name,
       data: data.map(([timestamp, value]) => [timestamp, typeof value === 'number' ? (value / bytes).toFixed(2) : null]),
-    }]
+    }],
+    annotations: window?.annotationsData || {}
   });
 }
 


### PR DESCRIPTION
I noticed that the deploy events were on some charts but not all. This adds them to usage and percentage charts, as well. I expect the PR will be red for the same reasons discussed in #160 