### PR TITLE
add .gitattributes to prevent issues with differing line endings.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Let Git handle line endings automatically based on what's already in the repo
+* text=auto
+
+# Denote binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary


### PR DESCRIPTION
I'm running Linux, and I'm guessing you're running Windows? I've been running into a lot of issues with Unix vs Windows line endings causing diffs to cover every line of the file, rather than just the specific lines I've changed. I think this should fix that and make it easier to contribute.