### PR TITLE
Run standardrb checks after tests in default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,12 +16,11 @@ end
 
 APP_RAKEFILE = File.expand_path("test/dummy/Rakefile", __dir__)
 load "rails/tasks/engine.rake"
-
 load "rails/tasks/statistics.rake"
 
 require "bundler/gem_tasks"
-
 require "rake/testtask"
+require "standard/rake"
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
@@ -29,4 +28,4 @@ Rake::TestTask.new(:test) do |t|
   t.verbose = false
 end
 
-task default: :test
+task default: [:test, :standard]


### PR DESCRIPTION
With this PR, running `rake` will run all the tests as before, followed up by the standardrb check. This should hopefully reduce the number of PRs that are pushed, only to fail on the standardrb CI job.