### PR TITLE
Restore rails ujs functionality.

### DIFF
--- a/app/engine_assets/javascripts/application.js
+++ b/app/engine_assets/javascripts/application.js
@@ -1,3 +1,6 @@
+import Rails from "@rails/ujs"
+Rails.start()
+
 import "rails_performance/charts"
 import "rails_performance/navbar"
 import "rails_performance/panel"

--- a/app/views/rails_performance/layouts/rails_performance.html.erb
+++ b/app/views/rails_performance/layouts/rails_performance.html.erb
@@ -15,6 +15,7 @@
     <link rel="shortcut icon" href="/favicon.ico">
 
     <%= engine_javascript_importmap_tags "application", {
+      "@rails/ujs" => "https://cdn.jsdelivr.net/npm/@rails/ujs@7.1.3-4/+esm",
       "jquery" => "https://cdn.jsdelivr.net/npm/jquery@3.7.1/+esm",
       "apexcharts" => "https://cdn.jsdelivr.net/npm/apexcharts@3.45.0/+esm",
       "stupid-table-plugin" => "https://cdn.jsdelivr.net/npm/stupid-table-plugin@1.1.3/+esm"


### PR DESCRIPTION
Just realized I accidentally left out the ujs dependency in the asset revamp PR, breaking the individual request slide-out functionality. This fixes that.