### PR TITLE
#179 Fix using ActionController::Metal for EngineAssets::Controller to avoid jbuilder compatibility issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem "daemons"
 
 gem "puma"
 
+gem "jbuilder"
 gem "sprockets-rails"
 
 gem "devise"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,9 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jbuilder (2.14.1)
+      actionview (>= 7.0.0)
+      activesupport (>= 7.0.0)
     json (2.15.1)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
@@ -347,6 +350,7 @@ DEPENDENCIES
   devise
   get_process_mem
   grape
+  jbuilder
   mimemagic (>= 0, = 0.4.3)
   ostruct
   puma

--- a/lib/rails_performance/engine_assets/controller.rb
+++ b/lib/rails_performance/engine_assets/controller.rb
@@ -1,6 +1,11 @@
 module RailsPerformance
   class EngineAssets
-    class Controller < ActionController::Base
+    class Controller < ActionController::Metal
+      include ActionController::DataStreaming
+      include ActionController::ConditionalGet
+      include ActionController::Head
+      include ActionController::Caching
+
       def show
         file_path = safe_file_path
 
@@ -29,13 +34,6 @@ module RailsPerformance
       def content_type
         format = params[:format] || request.format.symbol.to_s
         engine_assets.content_type(format)
-      end
-
-      # Override to allow cross-origin JavaScript embedding
-      # This is really dumb because it IS the same origin, but Chrome's import apparently doesn't send the Origin header.
-      # Is there a better way to resolve this?
-      def verify_same_origin_request
-        # no-op
       end
     end
   end

--- a/test/dummy/app/controllers/users_controller.rb
+++ b/test/dummy/app/controllers/users_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UsersController < ActionController::API
+  def index
+    @users = User.all
+  end
+end

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -28,6 +28,7 @@
       <li><%= link_to "Grape Internal Server Error", '/api/internal_server_error' %></li>
       <li><%= link_to "Grape Ping", '/api/ping' %></li>
       <li><%= link_to "Grape Crash", '/api/crash' %></li>
+      <li><%= link_to "JBuilder Users", '/users.json' %></li>
       <br>
       <li><%= link_to "Rails Performance Report", '/rails/performance' %></li>
     </ul>

--- a/test/dummy/app/views/users/index.json.jbuilder
+++ b/test/dummy/app/views/users/index.json.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.home root_url
+json.users do
+  json.array! @users, :id, :first_name, :age, :email
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
   get "home/blog"
   get "home/about.csv", to: "home#about"
 
+  resources :users, only: [:index], defaults: {format: :json}
+
   mount API => "/"
 
   root to: "home#index"

--- a/test/jbuilder_compatibility_test.rb
+++ b/test/jbuilder_compatibility_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class JbuilderCompatibilityTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = User.create!(first_name: "John", age: 30)
+
+    get users_path(format: :json)
+  end
+
+  test "endpoint returns valid JSON" do
+    assert_response :success
+    assert_equal "application/json", response.media_type
+
+    body = response.parsed_body
+    assert_kind_of Hash, body
+
+    expected = {
+      "home" => root_url,
+      "users" => [@user.as_json(only: %i[id first_name age email])]
+    }
+
+    assert_equal expected, body
+  end
+end


### PR DESCRIPTION
Closes #179 

After the assets revamp (commit 1583144), some applications using `jbuilder` gem started experiencing `TypeError: no implicit conversion of Hash into String` when calling `response.parsed_body`.

As workaround `require 'jbuilder/railtie'` can be added to `application.rb`.

The `EngineAssets::Controller` was inheriting from `ActionController::Base`. When a class inherits from `ActionController::Base`, Rails triggers the inherited callback which attempts to automatically load helpers (looking for `RailsPerformanceHelper` in this case).
This early interaction with `ActionController::Base` during gem loading interfered with jbuilder's template handler registration, causing JSON responses to be incorrectly processed.

#### Solution

Use `ActionController::Metal`as minimal controller implementation that doesn't include the helper auto-loading behavior or other middleware that can cause side effects during gem initialization. And explicitly include only required modules for serving static assets

`verify_same_origin_request` is no longer required after that (was needed for ActionController::Base)