### PR TITLE
#181 Fix chart data handling and potential bug in performance report caching

### DIFF
--- a/app/engine_assets/javascripts/charts.js
+++ b/app/engine_assets/javascripts/charts.js
@@ -43,7 +43,7 @@ class RailsPerformanceChart extends HTMLElement {
   updateChart(newData) {
     let incoming = newData;
     if (this.type === 'Usage') {
-      const { units, bytes } = calculateByteUnit(newData);
+      const { bytes } = calculateByteUnit(newData);
       incoming = newData.map(([t, v]) => [t, typeof v === 'number' ? (v / bytes).toFixed(2) : null]);
     }
     this.chart.updateRollingWindow(incoming, { windowSizeMs: this.windowSizeMs });
@@ -51,9 +51,9 @@ class RailsPerformanceChart extends HTMLElement {
 
   get windowSizeMs() {
     if (this.type === 'TIR' || this.type === 'RT') {
-      return ms("4h")
+      return window.railsPerformanceDuration || ms("4h");
     } else {
-      return ms("24h")
+      return ms("24h");
     }
   }
 

--- a/app/views/rails_performance/layouts/rails_performance.html.erb
+++ b/app/views/rails_performance/layouts/rails_performance.html.erb
@@ -25,6 +25,7 @@
 
     <script>
       window.annotationsData = <%= raw RailsPerformance::Reports::AnnotationsReport.new.data.to_json %>;
+      window.railsPerformanceDuration = <%= RailsPerformance.duration.to_i * 1000 %>;
     </script>
   </head>
 

--- a/lib/rails_performance/reports/base_report.rb
+++ b/lib/rails_performance/reports/base_report.rb
@@ -64,7 +64,8 @@ module RailsPerformance
       #   ....
       # }
       def nil_data(duration = RailsPerformance.duration)
-        @nil_data ||= begin
+        @nil_data_cache ||= {}
+        @nil_data_cache[duration] ||= begin
           result = {}
           now = RailsPerformance::Utils.kind_of_now
           now = now.change(sec: 0, usec: 0)


### PR DESCRIPTION
Closes #181 

- Fixed `windowSizeMs` getter to use a dynamic value from `RailsPerformance.duration`.
- Enhanced caching mechanism in `base_report.rb` to store `nil_data` based on duration (potential bug in case of different arguments).
